### PR TITLE
Update drupal7.md

### DIFF
--- a/docs/tutorials/drupal7.md
+++ b/docs/tutorials/drupal7.md
@@ -72,7 +72,7 @@ Here is the [recipe config](./../config/recipes.md#config) to set the Drupal 7 r
 ```yaml
 recipe: drupal7
 config:
-  php: 7.0
+  php: '7.0'
 ```
 
 ### Choosing a webserver


### PR DESCRIPTION
Used syntax for selecting php version is incorrect.  Lando prduces ```error: TypeError: Invalid Version: 7.0
```

- [ ] My code includes the latest code from the `master` branch
- [ ] My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/docs/changelog)
- [ ] My code includes a [functional test](https://docs.devwithlando.io/dev/testing.html#functional-tests) if applicable
- [ ] My code includes a [unit test](https://docs.devwithlando.io/dev/testing.html#unit-tests) if applicable
- [ ] My code includes documentation updates if applicable.
- [ ] My code passes relevant CI status checks
- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.
